### PR TITLE
feat: Update defaults for kafka operator

### DIFF
--- a/services/kafka-operator/0.20.0/defaults/cm.yaml
+++ b/services/kafka-operator/0.20.0/defaults/cm.yaml
@@ -7,5 +7,7 @@ metadata:
 data:
   values.yaml: |
     ---
+    certManager:
+      enabled: true
     crd:
       enabled: true


### PR DESCRIPTION
After looking through the defaults defined on the [koperator chart](https://github.com/banzaicloud/koperator/blob/master/charts/kafka-operator/values.yaml), I think this is the only other addition we need as of right now. Let me know what you think!